### PR TITLE
FEAT: Add track-based speeds

### DIFF
--- a/physics/environment/gis/base_gis.py
+++ b/physics/environment/gis/base_gis.py
@@ -24,6 +24,11 @@ class BaseGIS(ABC):
     def get_path(self) -> np.ndarray:
         raise NotImplementedError
 
+    @staticmethod
+    @abstractmethod
+    def calculate_speeds_and_position(speeds_kmh: NDArray, track_speeds, path_distances, dt):
+        raise NotImplementedError
+
     @abstractmethod
     def calculate_current_heading_array(self) -> np.ndarray:
         raise NotImplementedError

--- a/physics/environment/gis/gis.py
+++ b/physics/environment/gis/gis.py
@@ -81,7 +81,39 @@ class GIS(BaseGIS):
         :rtype: np.ndarray
 
         """
-        return physics_rs.closest_gis_indices_loop(distances, self.path_distances)
+        return self._python_calculate_closest_gis_indices(distances)
+        # return physics_rs.closest_gis_indices_loop(distances, self.path_distances)
+
+    @staticmethod
+    def calculate_speeds_and_position(speeds_kmh: NDArray, track_speeds, path_distances, dt):
+        result = []
+        actual_speeds_kmh = []
+
+        with tqdm(total=len(speeds_kmh), file=sys.stdout, desc="Calculating closest GIS indices") as pbar:
+            distance_travelled = 0
+            track_index = 0
+
+            for lap_speed in speeds_kmh:
+                if lap_speed > 0:
+                    actual_speed = lap_speed + track_speeds[track_index]
+                else:
+                    actual_speed = 0
+
+                actual_speeds_kmh.append(actual_speed)
+                distance_travelled += actual_speed * dt
+
+                while distance_travelled > path_distances[current_coordinate_index]:
+                    distance_travelled -= path_distances[current_coordinate_index]
+                    track_index += 1
+
+                    if current_coordinate_index >= len(path_distances):
+                        current_coordinate_index = 0
+
+                result.append(current_coordinate_index)
+                pbar.update(1)
+
+        return np.array(result), np.array(actual_speeds_kmh)
+
 
     def calculate_driving_speeds(
             self,

--- a/physics/environment/gis/gis.py
+++ b/physics/environment/gis/gis.py
@@ -34,21 +34,9 @@ class GIS(BaseGIS):
         self.path_time_zones = route_data['time_zones']
         self.num_unique_coords = route_data['num_unique_coords']
 
-        if current_coord is not None:
-            if not np.array_equal(current_coord, origin_coord):
-                logging.warning("Current position is not origin position. Modifying path data.\n")
-
-                # We need to find the closest coordinate along the path to the vehicle position
-                current_coord_index = GIS._find_closest_coordinate_index(current_coord, self.path)
-
-                # All coords before the current coordinate should be discarded
-                self.path = self.path[current_coord_index:]
-                self.path_elevations = self.path_elevations[current_coord_index:]
-                self.path_time_zones = self.path_time_zones[current_coord_index:]
-
-        self.path_distances = calculate_path_distances(self.path)
+        self.path_distances = calculate_path_distances(self.path)[:self.num_unique_coords]
         self.path_length = np.cumsum(calculate_path_distances(self.path[:self.num_unique_coords]))[-1]
-        self.path_gradients = calculate_path_gradients(self.path_elevations, self.path_distances)
+        self.path_gradients = calculate_path_gradients(self.path_elevations[:self.num_unique_coords], self.path_distances)
 
     @staticmethod
     def process_KML_file(route_file):
@@ -81,11 +69,25 @@ class GIS(BaseGIS):
         :rtype: np.ndarray
 
         """
-        return self._python_calculate_closest_gis_indices(distances)
-        # return physics_rs.closest_gis_indices_loop(distances, self.path_distances)
+        return physics_rs.closest_gis_indices_loop(distances, self.path_distances)
 
-    @staticmethod
-    def calculate_speeds_and_position(speeds_kmh: NDArray, track_speeds, path_distances, dt):
+    def calculate_speeds_and_position(self, speeds_kmh: NDArray, track_speeds: NDArray, dt: int):
+        try:
+            return physics_rs.calculate_speeds_and_position(speeds_kmh, self.path_distances, track_speeds, dt)
+
+        except Exception:
+            return self._py_calculate_speeds_and_position(speeds_kmh, track_speeds, dt)
+
+    def _py_calculate_speeds_and_position(self, speeds_kmh: NDArray, track_speeds: NDArray, dt: int):
+        """
+        Given the original, lap-averaged `speeds_kmh` and an array of speed deviations in km/h for each track index,
+        compute the position and actual speed as simulation-time arrays.
+
+        :param speeds_kmh: Lap-averaged speeds in km/h.
+        :param track_speeds: A speed deviation in km/h for each track index. Expects the mean to be at 0.
+        :param dt:
+        :return:
+        """
         result = []
         actual_speeds_kmh = []
 
@@ -102,18 +104,17 @@ class GIS(BaseGIS):
                 actual_speeds_kmh.append(actual_speed)
                 distance_travelled += actual_speed * dt
 
-                while distance_travelled > path_distances[current_coordinate_index]:
-                    distance_travelled -= path_distances[current_coordinate_index]
+                while distance_travelled > self.path_distances[track_index]:
+                    distance_travelled -= self.path_distances[track_index]
                     track_index += 1
 
-                    if current_coordinate_index >= len(path_distances):
-                        current_coordinate_index = 0
+                    if track_index >= len(self.path_distances):
+                        track_index = 0
 
-                result.append(current_coordinate_index)
+                result.append(track_index)
                 pbar.update(1)
 
         return np.array(result), np.array(actual_speeds_kmh)
-
 
     def calculate_driving_speeds(
             self,

--- a/physics/environment/gis/gis.rs
+++ b/physics/environment/gis/gis.rs
@@ -26,6 +26,44 @@ pub fn rust_closest_gis_indices_loop(
     result
 }
 
+pub fn calculate_speeds_and_position(
+    speeds_kmh: ArrayView1<'_, f64>,
+    path_distances: ArrayView1<'_, f64>,
+    track_speeds: ArrayView1<'_, f64>,
+    simulation_dt: u32,
+) -> (Vec<usize>, Vec<f64>) {
+    let mut track_index: usize = 0;
+    let mut distance_travelled: f64 = 0.0;
+    let n = path_distances.len();
+
+    let mut result: Vec<usize> = Vec::with_capacity(speeds_kmh.len());
+    let mut actual_speeds_kmh: Vec<f64> = Vec::with_capacity(speeds_kmh.len());
+
+    for &speed in speeds_kmh {
+        let actual_speed = if speed > 0.0 {
+            speed + track_speeds[track_index]
+        } else {
+            0.0
+        };
+
+        actual_speeds_kmh.push(actual_speed);
+        distance_travelled += actual_speed * simulation_dt as f64;
+
+        while distance_travelled > path_distances[track_index] {
+            distance_travelled -= path_distances[track_index];
+            track_index += 1;
+
+            if track_index >= n {
+                track_index = 0;
+            }
+        }
+
+        result.push(track_index);
+    }
+
+    (result, actual_speeds_kmh)
+}
+
 ///
 /// Generate valid driving speeds as a simulation-time array given a set of average speeds for each
 /// simulated lap.

--- a/physics/lib.rs
+++ b/physics/lib.rs
@@ -5,7 +5,7 @@ use pyo3::types::PyModule;
 
 pub mod environment;
 pub mod models;
-use crate::environment::gis::gis::{rust_closest_gis_indices_loop, get_driving_speeds};
+use crate::environment::gis::gis::{rust_closest_gis_indices_loop, get_driving_speeds, calculate_speeds_and_position};
 use crate::environment::meteorology::meteorology::{rust_calculate_array_ghi_times, rust_closest_weather_indices_loop, rust_weather_in_time};
 use crate::models::battery::battery::update_battery_state;
 
@@ -133,6 +133,29 @@ fn rust_simulation(_py: Python, m: &PyModule) -> PyResult<()> {
         let py_soc_array = PyArray::from_vec(py, soc_array);
         let py_voltage_array = PyArray::from_vec(py, voltage_array);
         (py_soc_array, py_voltage_array)
+    }
+
+    #[pyfn(m)]
+    #[pyo3(name = "calculate_speeds_and_position")]
+    fn calculate_speeds_and_position_py<'py>(
+        py: Python<'py>,
+        speeds_kmh_py: PyReadwriteArray1<'py, f64>,
+        path_distances_py: PyReadwriteArray1<'py, f64>,
+        track_speeds_py: PyReadwriteArray1<'py, f64>,
+        simulation_dt: u32,
+    ) -> (&'py PyArray1<usize>, &'py PyArray1<f64>) {
+        let speeds_kmh = speeds_kmh_py.as_array();
+        let path_distances = path_distances_py.as_array();
+        let track_speeds = track_speeds_py.as_array();
+        let (gis_indices, actual_speeds_kmh): (Vec<usize>, Vec<f64>) = calculate_speeds_and_position(
+            speeds_kmh,
+            path_distances,
+            track_speeds,
+            simulation_dt,
+        );
+        let gis_indices_py = PyArray::from_vec(py, gis_indices);
+        let actual_speeds_kmh_py = PyArray::from_vec(py, actual_speeds_kmh);
+        (gis_indices_py, actual_speeds_kmh_py)
     }
 
     #[pyfn(m)]


### PR DESCRIPTION
# [FEAT/FIX/DOCS]: Pull Request Name 

- [x] All Tests Succeeded
- [x] Module Documentation
- [x] Method/Class/Function Documentation
- [x] Documentation Correctly Builds 
- [x] Pull Request Completed 

## What's New
1. Added `calculate_speeds_and_position` to `GIS` which supersedes `closest_gis_indices` as it calculates the GIS index as well as the speed, given the track-index based speeds.

## Bugfixes
N/A

## Deprecated/Removed
N/A

## Dependencies
N/A

## Notes
N/A
